### PR TITLE
2.2.0 - give-free-form( Refatoração para lançamento no WordPress)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.2.0 - 10/03/2025
+* Fix with plugin-check
+
 # 2.1.0 - 19/02/2025
 * Givewp-form-builder checkbox field
 

--- a/includes/class-lkn-give-free-form-helper.php
+++ b/includes/class-lkn-give-free-form-helper.php
@@ -89,7 +89,7 @@ final class Lkn_Form_Customization_for_Give_Helper
             esc_html__('for the Donation Form Customization for GiveWP to activate.', LKN_DONATION_FORM_CUSTOMIZATION_TEXT_DOMAIN)
         );
 
-        echo $message;
+        echo wp_kses_post($message);
     }
 
     /**
@@ -109,7 +109,7 @@ final class Lkn_Form_Customization_for_Give_Helper
             esc_html__('plugin installed and activated for the Donation Form Customization for GiveWP.', LKN_DONATION_FORM_CUSTOMIZATION_TEXT_DOMAIN)
         );
 
-        echo $message;
+        echo wp_kses_post($message);
     }
 
     final public static function lkn_give_free_form_dependency_alert(): void

--- a/lkn-give-free-form.php
+++ b/lkn-give-free-form.php
@@ -26,7 +26,7 @@
  */
 
 // If this file is called directly, abort.
-if ( ! defined( 'WPINC' ) ) {
+if (! defined('WPINC')) {
     die;
 }
 
@@ -38,32 +38,32 @@ if ( ! defined( 'WPINC' ) ) {
  * @since 1.0.0
  */
 // Defines plugin version number for easy reference.
-if ( ! defined('LKN_DONATION_FORM_CUSTOMIZATION_VERSION')) {
+if (! defined('LKN_DONATION_FORM_CUSTOMIZATION_VERSION')) {
     define('LKN_DONATION_FORM_CUSTOMIZATION_VERSION', '2.0.0');
 }
 
 // Set it to latest.
-if ( ! defined('LKN_DONATION_FORM_CUSTOMIZATION_MIN_GIVE_VERSION')) {
+if (! defined('LKN_DONATION_FORM_CUSTOMIZATION_MIN_GIVE_VERSION')) {
     define('LKN_DONATION_FORM_CUSTOMIZATION_MIN_GIVE_VERSION', '2.3.0');
 }
 
-if ( ! defined('LKN_DONATION_FORM_CUSTOMIZATION_FILE')) {
+if (! defined('LKN_DONATION_FORM_CUSTOMIZATION_FILE')) {
     define('LKN_DONATION_FORM_CUSTOMIZATION_FILE', __FILE__);
 }
 
-if ( ! defined('LKN_DONATION_FORM_CUSTOMIZATION_DIR')) {
+if (! defined('LKN_DONATION_FORM_CUSTOMIZATION_DIR')) {
     define('LKN_DONATION_FORM_CUSTOMIZATION_DIR', plugin_dir_path(LKN_DONATION_FORM_CUSTOMIZATION_FILE));
 }
 
-if ( ! defined('LKN_DONATION_FORM_CUSTOMIZATION_URL')) {
+if (! defined('LKN_DONATION_FORM_CUSTOMIZATION_URL')) {
     define('LKN_DONATION_FORM_CUSTOMIZATION_URL', plugin_dir_url(LKN_DONATION_FORM_CUSTOMIZATION_FILE));
 }
 
-if ( ! defined('LKN_DONATION_FORM_CUSTOMIZATION_BASENAME')) {
+if (! defined('LKN_DONATION_FORM_CUSTOMIZATION_BASENAME')) {
     define('LKN_DONATION_FORM_CUSTOMIZATION_BASENAME', plugin_basename(LKN_DONATION_FORM_CUSTOMIZATION_FILE));
 }
 
-if ( ! defined('LKN_DONATION_FORM_CUSTOMIZATION_TEXT_DOMAIN')) {
+if (! defined('LKN_DONATION_FORM_CUSTOMIZATION_TEXT_DOMAIN')) {
     define('LKN_DONATION_FORM_CUSTOMIZATION_TEXT_DOMAIN', 'lkn-give-free-form');
 }
 
@@ -71,8 +71,9 @@ if ( ! defined('LKN_DONATION_FORM_CUSTOMIZATION_TEXT_DOMAIN')) {
  * The code that runs during plugin activation.
  * This action is documented in includes/class-lkn-give-free-form-activator.php
  */
-function activate_lkn_give_free_form(): void {
-    require_once plugin_dir_path( __FILE__ ) . 'includes/class-lkn-give-free-form-activator.php';
+function activate_lkn_give_free_form(): void
+{
+    require_once plugin_dir_path(__FILE__) . 'includes/class-lkn-give-free-form-activator.php';
     Lkn_Form_Customization_for_Give_Activator::activate();
 }
 
@@ -80,19 +81,20 @@ function activate_lkn_give_free_form(): void {
  * The code that runs during plugin deactivation.
  * This action is documented in includes/class-lkn-give-free-form-deactivator.php
  */
-function deactivate_lkn_give_free_form(): void {
-    require_once plugin_dir_path( __FILE__ ) . 'includes/class-lkn-give-free-form-deactivator.php';
+function deactivate_lkn_give_free_form(): void
+{
+    require_once plugin_dir_path(__FILE__) . 'includes/class-lkn-give-free-form-deactivator.php';
     Lkn_Form_Customization_for_Give_Deactivator::deactivate();
 }
 
-register_activation_hook( __FILE__, 'activate_lkn_give_free_form' );
-register_deactivation_hook( __FILE__, 'deactivate_lkn_give_free_form' );
+register_activation_hook(__FILE__, 'activate_lkn_give_free_form');
+register_deactivation_hook(__FILE__, 'deactivate_lkn_give_free_form');
 
 /**
  * The core plugin class that is used to define internationalization,
  * admin-specific hooks, and public-facing site hooks.
  */
-require plugin_dir_path( __FILE__ ) . 'includes/class-lkn-give-free-form.php';
+require plugin_dir_path(__FILE__) . 'includes/class-lkn-give-free-form.php';
 
 /**
  * Begins execution of the plugin.
@@ -103,7 +105,8 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-lkn-give-free-form.php';
  *
  * @since    1.0.0
  */
-function run_lkn_give_free_form(): void {
+function run_lkn_give_free_form(): void
+{
     $plugin = new Lkn_Form_Customization_for_Give();
     $plugin->run();
 }

--- a/lkn-give-free-form.php
+++ b/lkn-give-free-form.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Donation Form Customization for GiveWP
  * Plugin URI:        https://www.linknacional.com.br/wordpress/givewp/give-free-form/
  * Description:       Form styling plugin for GiveWP.
- * Version:           2.1.0
+ * Version:           2.2.0
  * Author:            Link Nacional
  * Author URI:        https://www.linknacional.com.br
  * License:           GPL-3.0+

--- a/public/class-lkn-give-free-form-public.php
+++ b/public/class-lkn-give-free-form-public.php
@@ -20,7 +20,8 @@
  * @subpackage Lkn_Form_Customization_for_Give/public
  * @author     Link Nacional
  */
-final class Lkn_Form_Customization_for_Give_Public {
+final class Lkn_Form_Customization_for_Give_Public
+{
     /**
      * The ID of this plugin.
      *
@@ -46,7 +47,8 @@ final class Lkn_Form_Customization_for_Give_Public {
      * @param      string    $plugin_name       The name of the plugin.
      * @param      string    $version    The version of this plugin.
      */
-    public function __construct( $plugin_name, $version ) {
+    public function __construct($plugin_name, $version)
+    {
         $this->plugin_name = $plugin_name;
         $this->version = $version;
     }
@@ -59,415 +61,26 @@ final class Lkn_Form_Customization_for_Give_Public {
      * @param array $args - list of additional arguments
      *
      */
-    public function form_customization($form_id, $args): void {
-        $id_prefix = ! empty($args) ? $args : '';
-
-        $status = get_post_meta($form_id, 'free_form-fields_lkn_form_style_status', true);
-        $color = get_post_meta($form_id, 'free_form-fields_lkn_form_color', true);
-        $colorDet = get_post_meta($form_id, 'free_form-fields_lkn_details_color', true);
-        $titleColor = get_post_meta($form_id, 'free_form-fields_lkn_title_color', true);
-        $titleSize = get_post_meta($form_id, 'free_form-fields_lkn_title_size', true);
-        $margin = get_post_meta($form_id, 'free_form-fields_lkn_section_margin', true);
-        $btnBorderColor = get_post_meta($form_id, 'free_form-fields_lkn_btn_border_color', true);
-        $btnBorderSize = get_post_meta($form_id, 'free_form-fields_lkn_btn_border_size', true);
-        $btnBorderRadius = get_post_meta($form_id, 'free_form-fields_lkn_btn_border_radius', true);
-        $paddingA = get_post_meta($form_id, 'free_form-fields_lkn_btn_paddingA', true);
-        $paddingL = get_post_meta($form_id, 'free_form-fields_lkn_btn_paddingL', true);
-        $textSize = get_post_meta($form_id, 'free_form-fields_lkn_btn_text_size', true);
-        $css = get_post_meta($form_id, 'free_form-fields_lkn_css', true);
-        $stripeCss = get_post_meta($form_id, 'free_form-fields_stripe_input_lkn_css', true);
-
-        if ('enabled' !== $status) {
-            echo '';
-        } else {
-            $formCustomization = <<<HTML
-        <style>
-            .lkn_notice_wrapper {
-                display: flex;
-                flex-direction: row;
-                justify-content: center;
-                align-items: center;
-                margin-top: 75px;
-            }
-
-            .lknNoticeText {
-                font-size: 10px;
-                color: #989898;
-            }
-
-            .lknIframeText {
-                font-size: 13px;
-            }
-
-            .lknIframeWrapper {
-                margin-top: 25px;
-                margin-bottom: 25px;
-            }
-
-            #give-purchase-button{
-                background-color: $color;
-                color: $colorDet;
-                padding: 18px 70px;
-                font-size: 1.4em;
-                line-height: 1.4em;
-                font-weight: 600;
-                border-radius: 15px;
-            }
-
-            .give-submit-button-wrap{
-                display: flex;
-                justify-content: center;
-                align-items: center;
-            }
-
-            .give-submit-button-wrap:focus{
-                filter: brightness(120%);
-            }
-
-            [id*=give-form] div.summary{
-                width: 100%;
-                float: none;
-            }
-
-            #give-sidebar-left{
-                display: none;
-            }
-
-            #lkn_give_purchase_form_wrap{
-                display: none;
-            }
-
-            .give-donation-level-btn{
-                display: inline-flex;
-                align-items: center;
-                justify-content: center;
-                background-color: $color;
-                border: $btnBorderSize solid $btnBorderColor;
-                border-radius: $btnBorderRadius;
-                color: $colorDet;
-                padding: 12px 15px;
-                cursor: pointer;
-                line-height: 1.7em;
-                font-size: $textSize;
-                width: 100%;
-                height: 100%;
-            }
-
-            .give-donation-level-btn:hover{
-                background-color: $color;
-                color: $colorDet;
-                filter: brightness(120%);
-            }
-
-            .give-default-level:hover{
-                background-color: $colorDet;
-                color: $color;
-                filter: brightness(120%);
-            }
-
-            .give-default-level{
-                background-color: $colorDet;
-                color: $color;
-            }
-
-            form[id*=give-form] #give-gateway-radio-list>li input[type=radio]{
-                display: none;
-            }
-
-            .give-gateway-option-selected{
-                background-color: $colorDet !important;
-                color: $color !important;
-            }
-
-            form[id*=give-form] #give-gateway-radio-list>li{
-                background-color: $color;
-                color: $colorDet;
-                border: solid $btnBorderSize $btnBorderColor;
-                margin: 5px;
-                text-align: center;
-                justify-content: center;
-                align-items: center;
-                display: flex;
-                cursor: pointer;
-                line-height: 2em;
-                font-weight: 600;
-                height: 100%;
-                font-size: $textSize;
-                border-radius: $btnBorderRadius;
-            }
-
-            form[id*=give-form] #give-gateway-radio-list {
-                display: grid;
-                grid-gap: 10px;
-                grid-template-columns: repeat(3,minmax(0,1fr));
-            }
-
-            .give-btn-level-custom{
-                font-size: $textSize;
-                font-weight: 600;
-            }
-
-            .give-total-wrap{
-                display: flex;
-                justify-content: center;
-                align-items: center;
-            }
-
-            form[id*=give-form] .give-donation-amount .give-currency-symbol{
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                text-align: center;
-                font-size: 1.4em;
-                background-color: transparent;
-            }
-
-            form[id*=give-form] .give-donation-amount .give-currency-symbol.give-currency-position-before{
-                border-top: none;
-                border-bottom: none;
-                border-left: none;
-                border-right: 2px solid darkgrey;
-            }
-
-            form[id*=give-form] .give-donation-amount .give-currency-symbol.give-currency-position-after{
-                border-top: none;
-                border-bottom: none;
-                border-left: 2px solid darkgrey;
-                border-right: none;
-            }
-
-            .give-donation-amount{
-                width: fit-content;
-                max-width: 80%;
-                justify-content: center;
-                align-items: center;
-                display: flex;
-                box-shadow: inset 0 1px 4px rgb(0 0 0 / 22%);
-                border-radius: 5px;
-                overflow: hidden;
-                padding: 12px 16px;
-                float: none;
-                border-image: linear-gradient(to right, $colorDet, $color) 1;
-                border-left: none;
-                border-right: none;
-                border-top: none;
-                border-bottom: 3px solid;
-            }
-
-            form[id*=give-form] .give-donation-amount{
-                margin: 5px auto 15px;
-            }
-
-            form[id*=give-form] .give-donation-amount #give-amount, form[id*=give-form] .give-donation-amount #give-amount-text{
-                display: block;
-                text-align: center;
-                border: none;
-                line-height: 1.7em;
-                height: auto;
-                font-size: 1.7em;
-                min-width: 180px;
-            }
-
-            #give-donation-level-button-wrap{
-                display: grid;
-                grid-gap: 10px;
-                grid-template-columns: repeat(3,minmax(0,1fr));
-                margin: 16px 80px;
-            }
-
-            #give-donation-level-button-wrap:after, #give-donation-level-button-wrap:before {
-                content: none;
-            }
-
-            form[id*=give-form] #give-gateway-radio-list:after, form[id*=give-form] #give-gateway-radio-list:before{
-                content: none;
-            }
-
-            #give_checkout_user_info, #give-payment-mode-select {
-                margin: $margin 0px;
-            }
-
-            #give-recurring-form h3.give-section-break, #give-recurring-form h4.give-section-break, #give-recurring-form legend, form.give-form h3.give-section-break, form.give-form h4.give-section-break, form.give-form legend, form[id*=give-form] h3.give-section-break, form[id*=give-form] h4.give-section-break, form[id*=give-form] legend{
-                color: $titleColor;
-                font-size: $titleSize;
-            }
-
-            #give-recurring-form .form-row .give-input-field-wrapper, #give-recurring-form .form-row input[type=email], #give-recurring-form .form-row input[type=password], #give-recurring-form .form-row input[type=tel], #give-recurring-form .form-row input[type=text], #give-recurring-form .form-row input[type=url], #give-recurring-form .form-row select, #give-recurring-form .form-row textarea, form.give-form .form-row .give-input-field-wrapper, form.give-form .form-row input[type=email], form.give-form .form-row input[type=password], form.give-form .form-row input[type=tel], form.give-form .form-row input[type=text], form.give-form .form-row input[type=url], form.give-form .form-row select, form.give-form .form-row textarea, form[id*=give-form] .form-row .give-input-field-wrapper, form[id*=give-form] .form-row input[type=email], form[id*=give-form] .form-row input[type=password], form[id*=give-form] .form-row input[type=tel], form[id*=give-form] .form-row input[type=text], form[id*=give-form] .form-row input[type=url], form[id*=give-form] .form-row select, form[id*=give-form] .form-row textarea{
-                border: solid 2px #ccc;
-                border-radius: 5px;
-            }
-
-            .give-input{
-                font-size: 1.3em;
-                box-shadow: inset 0 1px 4px rgb(0 0 0 / 22%);
-                border: solid 2px #ccc;
-                border-radius: 5px;
-                line-height: 1.3em;
-            }
-
-            .give-stripe-single-cc-field-wrap {
-                $stripeCss
-            }
-
-            .form-row .give-stripe-cc-field {
-                $stripeCss
-            }
-
-            #give-recurring-form .form-row .give-input-field-wrapper:focus, #give-recurring-form .form-row input[type=email]:focus, #give-recurring-form .form-row input[type=password]:focus, #give-recurring-form .form-row input[type=tel]:focus, #give-recurring-form .form-row input[type=text]:focus, #give-recurring-form .form-row input[type=url]:focus, #give-recurring-form .form-row select:focus, #give-recurring-form .form-row textarea:focus, form.give-form .form-row .give-input-field-wrapper:focus, form.give-form .form-row input[type=email]:focus, form.give-form .form-row input[type=password]:focus, form.give-form .form-row input[type=tel]:focus, form.give-form .form-row input[type=text]:focus, form.give-form .form-row input[type=url]:focus, form.give-form .form-row select:focus, form.give-form .form-row textarea:focus, form[id*=give-form] .form-row .give-input-field-wrapper:focus, form[id*=give-form] .form-row input[type=email]:focus, form[id*=give-form] .form-row input[type=password]:focus, form[id*=give-form] .form-row input[type=tel]:focus, form[id*=give-form] .form-row input[type=text]:focus, form[id*=give-form] .form-row input[type=url]:focus, form[id*=give-form] .form-row select:focus, form[id*=give-form] .form-row textarea:focus{
-                border-image: linear-gradient(to right, #666, $color) 1;
-            }
-
-            .give-form .give-stripe-cc-field.focus, .give-form .give-stripe-cc-field:focus {
-                border-image: linear-gradient(to right, #666, $color) 1 !important;
-            }
-
-            #give-final-total-wrap{
-                display: flex;
-                justify-content: center;
-                align-items: center;
-                text-align: center;
-            }
-
-            form[id*=give-form] #give-final-total-wrap .give-donation-total-label{
-                box-shadow: inset 0 1px 4px rgb(0 0 0 / 22%);
-            }
-
-            form[id*=give-form] #give-final-total-wrap .give-final-total-amount{
-                box-shadow: inset 0 1px 4px rgb(0 0 0 / 22%);
-            }
-
-            .give-btn-reveal{
-                display: flex;
-                justify-content: center;
-                align-items: center;
-                text-align: center;
-                background-color: $color;
-                color: $colorDet;
-                padding: $paddingA $paddingL;
-                font-size: $textSize;
-                line-height: 1.4em;
-                font-weight: 600;
-                border-radius: $btnBorderRadius;
-            }
-
-            #give-purchase-button {
-                border-radius: $btnBorderRadius;
-                padding: $paddingA $paddingL;
-                font-size: $textSize;
-            }
-
-            #give-purchase-button:hover {
-                background: $color;
-                filter: brightness(120%);
-                border-radius: $btnBorderRadius;
-            }
-
-            [id*=give-form].give-display-modal .give-btn, [id*=give-form].give-display-reveal .give-btn{
-                padding: $paddingA $paddingL;
-                margin: 0px auto;
-            }
-
-            .give-btn-reveal:hover{
-                background: $color;
-                filter: brightness(120%);
-            }
-
-            [id*=give-form] .give-custom-amount-text{
-                margin: 5px auto 15px;
-                display: flex;
-                justify-content: center;
-                align-items: center;
-                text-align: center;
-                font-size: 1.2em;
-            }
-
-            @media screen and (max-width: 850px) {
-                #give-donation-level-button-wrap{
-                    margin: 16px 20px;
-                }
-
-                form[id*=give-form] #give-gateway-radio-list>li{
-                    font-size: 1em;
-                }
-            }
-
-            @media screen and (max-width: 500px) {
-                .give-donation-level-btn{
-                    font-size: 1.4em;
-                }
-
-                .give-donation-amount{
-                    max-width: 100%;
-                }
-
-                #give-donation-level-button-wrap{
-                    grid-gap: 8px;
-                    grid-template-columns: repeat(2,minmax(0,1fr));
-                    margin: 8px 0px;
-                }
-
-                form[id*=give-form] #give-gateway-radio-list {
-                    display: grid;
-                    grid-gap: 8px;
-                    grid-template-columns: repeat(2,minmax(0,1fr));
-                }
-
-                form[id*=give-form] #give-final-total-wrap .give-donation-total-label{
-                    font-size: 13px;
-                }
-
-                form[id*=give-form] #give-final-total-wrap .give-final-total-amount{
-                    font-size: 13px;
-                }
-
-                .give-btn-level-custom{
-                    font-size: 14px;
-                    font-weight: 600;
-                }
-            }
-
-            .lkn-btn-gateway {
-                display: flex;
-                justify-content: center;
-                align-items: center;
-                text-align: center;
-                background-color: $color;
-                color: $colorDet;
-                padding: $paddingA $paddingL;
-                font-size: $textSize;
-                line-height: 1.4em;
-                font-weight: 600;
-                border-radius: $btnBorderRadius;
-            }
-
-            .lkn-btn-gateway:hover{
-                background-color: $color;
-                color: $colorDet;
-                filter: brightness(120%);
-            }
-            $css
-            {}
-
-        </style>
-HTML;
-            echo $formCustomization;
-        }
+    public function form_customization($form_id, $args): void
+    {
+        require_once LKN_DONATION_FORM_CUSTOMIZATION_DIR . 'public/partials/class-lkn-give-free-form-customization.php';
     }
 
     /**
      * Adds the mensage notice that's redirect for Link Nacional page on form footer.
      */
-    public function lkn_give_free_form_footer_notice(): void {
+    public function lkn_give_free_form_footer_notice(): void
+    {
         $link = esc_html__('https://www.linknacional.com.br/plataforma-de-doacoes/', LKN_DONATION_FORM_CUSTOMIZATION_TEXT_DOMAIN);
         $message = esc_html__('Secure donation platform', LKN_DONATION_FORM_CUSTOMIZATION_TEXT_DOMAIN);
 
-        $html = <<<HTML
-        <div class="lkn_notice_wrapper">
-            <span class="dashicons dashicons-lock" style="color=#989898;"></span>
-            <a href="{$link}" target="_blank" style="color: #666;text-decoration: none;"><span class="lknNoticeText"> {$message}</span></a>
-        </div>
-HTML;
-        echo $html;
+        $html = '<div class="lkn_notice_wrapper">
+            <span class="dashicons dashicons-lock" style="color: #989898;"></span>
+            <a href="' . esc_url($link) . '" target="_blank" style="color: #666; text-decoration: none;">
+                <span class="lknNoticeText">' . esc_html($message) . '</span>
+            </a>
+        </div>';
+        echo wp_kses_post($html);
     }
 
     /**
@@ -475,7 +88,8 @@ HTML;
      *
      * @since    1.0.0
      */
-    public function enqueue_scripts(): void {
+    public function enqueue_scripts(): void
+    {
         /**
          * This function is provided for demonstration purposes only.
          *
@@ -487,6 +101,6 @@ HTML;
          * between the defined hooks and the functions defined in this
          * class.
          */
-        wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/lkn-give-free-form-public.js', array('jquery'), $this->version, false );
+        wp_enqueue_script($this->plugin_name, plugin_dir_url(__FILE__) . 'js/lkn-give-free-form-public.js', array('jquery'), $this->version, false);
     }
 }

--- a/public/partials/class-lkn-give-free-form-customization.php
+++ b/public/partials/class-lkn-give-free-form-customization.php
@@ -1,0 +1,173 @@
+<?php
+$id_prefix = !empty($args) ? $args : '';
+$form_meta_keys = [
+    'free_form-fields_lkn_form_style_status' => 'status',
+    'free_form-fields_lkn_form_color' => 'color',
+    'free_form-fields_lkn_details_color' => 'colorDet',
+    'free_form-fields_lkn_title_color' => 'titleColor',
+    'free_form-fields_lkn_title_size' => 'titleSize',
+    'free_form-fields_lkn_section_margin' => 'margin',
+    'free_form-fields_lkn_btn_border_color' => 'btnBorderColor',
+    'free_form-fields_lkn_btn_border_size' => 'btnBorderSize',
+    'free_form-fields_lkn_btn_border_radius' => 'btnBorderRadius',
+    'free_form-fields_lkn_btn_paddingA' => 'paddingA',
+    'free_form-fields_lkn_btn_paddingL' => 'paddingL',
+    'free_form-fields_lkn_btn_text_size' => 'textSize',
+    'free_form-fields_lkn_css' => 'css',
+    'free_form-fields_stripe_input_lkn_css' => 'stripeCss',
+];
+
+foreach ($form_meta_keys as $meta_key => $var_name) {
+    $$var_name = get_post_meta($form_id, $meta_key, true);
+}
+
+if ($status !== 'enabled') {
+    return;
+}
+?>
+
+<style>
+    .lkn_notice_wrapper {
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        align-items: center;
+        margin-top: 75px;
+    }
+    .lknNoticeText {
+        font-size: 10px;
+        color: #989898;
+    }
+    .lknIframeText {
+        font-size: 13px;
+    }
+    .lknIframeWrapper {
+        margin-top: 25px;
+        margin-bottom: 25px;
+    }
+
+    #give-purchase-button {
+        background-color: <?php echo esc_attr($color) ?>;
+        color: <?php echo esc_attr($colorDet) ?>;
+        padding: 18px 70px;
+        font-size: 1.4em;
+        line-height: 1.4em;
+        font-weight: 600;
+        border-radius: 15px;
+    }
+
+    .give-submit-button-wrap {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .give-submit-button-wrap:focus {
+        filter: brightness(120%);
+    }
+
+    [id*=give-form] div.summary {
+        width: 100%;
+        float: none;
+    }
+
+    #give-sidebar-left,
+    #lkn_give_purchase_form_wrap {
+        display: none;
+    }
+
+    .give-donation-level-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background-color: <?php echo esc_attr($color) ?>;
+        border: <?php echo esc_attr($btnBorderSize) ?> solid <?php echo esc_attr($btnBorderColor) ?>;
+        border-radius: <?php echo esc_attr($btnBorderRadius) ?>;
+        color: <?php echo esc_attr($colorDet) ?>;
+        padding: 12px 15px;
+        cursor: pointer;
+        line-height: 1.7em;
+        font-size: <?php echo esc_attr($textSize) ?>;
+        width: 100%;
+        height: 100%;
+    }
+
+    .give-donation-level-btn:hover,
+    .give-default-level:hover {
+        background-color: <?php echo esc_attr($color) ?>;
+        color: <?php echo esc_attr($colorDet) ?>;
+        filter: brightness(120%);
+    }
+
+    .give-default-level {
+        background-color: <?php echo esc_attr($colorDet) ?>;
+        color: <?php echo esc_attr($color) ?>;
+    }
+
+    form[id*=give-form] #give-gateway-radio-list > li input[type=radio] {
+        display: none;
+    }
+
+    .give-gateway-option-selected {
+        background-color: <?php echo esc_attr($colorDet) ?> !important;
+        color: <?php echo esc_attr($color) ?> !important;
+    }
+
+    form[id*=give-form] #give-gateway-radio-list > li {
+        background-color: <?php echo esc_attr($color) ?>;
+        color: <?php echo esc_attr($colorDet) ?>;
+        border: solid <?php echo esc_attr($btnBorderSize) ?> <?php echo esc_attr($btnBorderColor) ?>;
+        margin: 5px;
+        text-align: center;
+        justify-content: center;
+        align-items: center;
+        display: flex;
+        cursor: pointer;
+        line-height: 2em;
+        font-weight: 600;
+        height: 100%;
+        font-size: <?php echo esc_attr($textSize) ?>;
+        border-radius: <?php echo esc_attr($btnBorderRadius) ?>;
+    }
+
+    form[id*=give-form] #give-gateway-radio-list {
+        display: grid;
+        grid-gap: 10px;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .give-total-wrap {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+
+    form[id*=give-form] .give-donation-amount {
+        width: fit-content;
+        max-width: 80%;
+        justify-content: center;
+        align-items: center;
+        display: flex;
+        box-shadow: inset 0 1px 4px rgb(0 0 0 / 22%);
+        border-radius: 5px;
+        overflow: hidden;
+        padding: 12px 16px;
+        float: none;
+        border-image: linear-gradient(to right, <?php echo esc_attr($colorDet) ?>, <?php echo esc_attr($color) ?>) 1;
+        border-left: none;
+        border-right: none;
+        border-top: none;
+        border-bottom: 3px solid;
+    }
+
+    form[id*=give-form] .give-donation-amount #give-amount,
+    form[id*=give-form] .give-donation-amount #give-amount-text {
+        display: block;
+        text-align: center;
+        border: none;
+        line-height: 1.7em;
+        height: auto;
+        font-size: 1.7em;
+        min-width: 180px;
+    }
+</style>

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,10 @@ At finish this steps, the Donation Form Customization for GiveWP is now activate
 
 == Changelog ==
 
+= 2.2.0 =
+**10/03/2025**
+* Fix with plugin-check
+
 = 2.1.0 =
 **19/02/2025**
 * Givewp-form-builder checkbox field

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/givewp/give-free-form/
 Tags: givewp, donate, form, customization, styling
 Requires at least: 5.5
 Tested up to: 6.7
-Stable tag: 2.1.0
+Stable tag: 2.2.0
 Requires PHP: 7.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: linknacional
 Donate link: https://www.linknacional.com.br/wordpress/givewp/give-free-form/
 Tags: givewp, donate, form, customization, styling
 Requires at least: 5.5
-Tested up to: 6.3
+Tested up to: 6.7
 Stable tag: 2.1.0
 Requires PHP: 7.2
 License: GPLv3 or later


### PR DESCRIPTION
# Give Free Form

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: givewp, form, free, builder, give

Testado até: 6.7.2

Versão estável: 2.2.0

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil)

Personalização de Formulário de Doação para GiveWP.

## Descrição

Personalização Avançada de Formulários de Doação para GiveWP: Aprimore a Experiência dos Seus Doadores.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".

## Resumo(2.2.0):

> Refatoração do plugin para lançamento com o Wordpress:

* Plugin utilizado para verificação: `Plugin-check`