### PR TITLE
2.2.1 - give-free-form(Correção na URL da API da LinkNacional)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
 env:
   PLUGIN_NAME: lkn-give-free-form
   PLUGIN_NAME_WITH_UPDATER: lkn-give-free-form-updt
+  DEPLOY_TAG: "2.2.1"
 
 jobs:
   release-build:
@@ -60,6 +61,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        custom_tag: ${{ env.DEPLOY_TAG }}
 
     # Generate new release
     - name: Generate new Release


### PR DESCRIPTION
# Give Free Form

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: givewp, form, free, builder, give

Testado até: 6.7.2

Versão estável: 2.2.1

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil)

Personalização de Formulário de Doação para GiveWP.

## Descrição

Personalização Avançada de Formulários de Doação para GiveWP: Aprimore a Experiência dos Seus Doadores.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".

## Resumo(2.2.1):

- Correção na URL da API da LinkNacional: 

* .com.br(OLD) -> .com(NEW)